### PR TITLE
Update some workflow actions to avoid security vulnerability. [fixes #47]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,30 +33,30 @@ jobs:
           dotnet-version: 3.0.x
 
       - name: "[Setup] - Install GitVersion"
-        uses: gittools/actions/gitversion/setup@v0.9.9
+        uses: gittools/actions/gitversion/setup@v0.9.11
         with:
           versionSpec: '5.6.6'
 
       - name: "[Setup] - Install GitReleaseManager"
         if: ${{ github.event_name == 'push' }}
-        uses: gittools/actions/gitreleasemanager/setup@v0.9.9
+        uses: gittools/actions/gitreleasemanager/setup@v0.9.11
         with:
           versionSpec: '0.11.0'
 
       - name: "[Versioning] - GitVersion Config"
-        uses: gittools/actions/gitversion/execute@v0.9.9
+        uses: gittools/actions/gitversion/execute@v0.9.11
         with:
           useConfigFile: true
           additionalArguments: '/showConfig'
 
       - name: "[Versioning] - Determine Version"
-        uses: gittools/actions/gitversion/execute@v0.9.9
+        uses: gittools/actions/gitversion/execute@v0.9.11
         id: gitversion
         with:
           useConfigFile: true
 
       - name: "[Versioning] - Update csproj Files"
-        uses: gittools/actions/gitversion/execute@v0.9.9
+        uses: gittools/actions/gitversion/execute@v0.9.11
         with:
           useConfigFile: true
           additionalArguments: '/updateprojectfiles'


### PR DESCRIPTION
#47 points out that we're depending on some old versions of GitHub actions that may have a security vulnerability. This pull request updates them to versions without the vulnerability (except addasset, which I'm not sure how to deal with).